### PR TITLE
Update checkstyle config to take tests into account.

### DIFF
--- a/corleone/build.gradle
+++ b/corleone/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'checkstyle'
 
 task checkstyle(type: Checkstyle) {
   configFile file('../config/checkstyle/checkstyle.xml')
-  source 'src/main/java'
+  source 'src'
   include '**/*.java'
   exclude '**/gen/**'
 


### PR DESCRIPTION
Change checkstyle configuration to use src as root directory instead of src/main/java. With this new configuration your tests will follow the same code style the rest of your code uses.
